### PR TITLE
Default to Poisson goal simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,24 +21,20 @@ example will execute the Monte Carlo iterations using four parallel processes.
 The summary table is automatically saved as `brasileirao.html` in the same
 directory as `main.py`. Pass `--html-output <file>` to choose a custom path.
 Use `--from-date YYYY-MM-DD` to ignore results on or after a given date and
-simulate from that point forward. Use `--auto-calibrate` to derive the draw
-percentage and home advantage from past seasons before running the simulation.
-When this flag is supplied, every file matching `data/Brasileirao????A.txt` is
-loaded automatically (except the file provided via `--file`).
+simulate from that point forward. Use `--auto-calibrate` to derive the home
+advantage from past seasons before running the simulation. When this flag is
+supplied, every file matching `data/Brasileirao????A.txt` is loaded
+automatically (except the file provided via `--file`).
 
-The default draw rate and home-field advantage are
-`DEFAULT_TIE_PERCENT` (33.3) and `DEFAULT_HOME_FIELD_ADVANTAGE` (1.0).
-Use `--tie-percent` and `--home-advantage` to override these values on the
-command line. `DEFAULT_JOBS` still defines the parallelism level.
+Matches are simulated using Poisson goal generation by default with expected
+goals of `1.0` for both home and away teams. Override these values with the
+`--home-goals-mean` and `--away-goals-mean` options to explore different scoring
+environments. The home-field advantage multiplier defaults to
+`DEFAULT_HOME_FIELD_ADVANTAGE` (1.0) and can be changed via `--home-advantage`.
+`DEFAULT_JOBS` still defines the parallelism level.
 
-Pass `--home-goals-mean` and `--away-goals-mean` to sample scores from Poisson
-distributions with the given expected values instead of the basic win/draw/loss
-model. These options can also be provided programmatically via the simulation
+These options can also be provided programmatically via the simulation
 functions.
-
-Alternatively, pass `--auto-calibrate` to estimate these parameters using all
-historical files in the `data/` directory. The computed draw rate and home
-advantage are then used for the simulation.
 
 Use ``estimate_team_strengths`` to calculate attack and defense multipliers for
 each club:
@@ -52,8 +48,9 @@ Pass ``strengths`` via the ``team_params`` argument when calling the simulation
 functions to incorporate team quality into the projections.
 
 By default matches are simulated purely at random with all teams considered
-equal. When expected goals are supplied the scores are drawn from Poisson
-distributions using those averages.
+equal, using the same expected goals for every side. When different expected
+goal values or team strength parameters are supplied, the Poisson means are
+scaled accordingly.
 
 The script outputs the estimated chance of winning the title for each team. It then prints the probability of each side finishing in the bottom four and being relegated. It also estimates the average final position and points of every club.
 All of these metrics are derived from a single Monte Carlo loop so that title chances, relegation odds and projected points remain consistent.
@@ -94,10 +91,9 @@ from simulator import (
 All simulation functions accept an optional ``n_jobs`` argument to control the
 degree of parallelism. By default ``n_jobs`` is set to the number of CPU cores,
 so simulations automatically run in parallel. When ``n_jobs`` is greater than
-one, joblib is used to distribute the work across multiple workers. The tie
-percentage and home advantage are fixed at their defaults of 33.3% and 1.0.
-Provide expected goal values via ``home_goals_mean`` and ``away_goals_mean`` to
-enable Poisson-based scoring.
+one, joblib is used to distribute the work across multiple workers. Expected
+goal values are controlled via ``home_goals_mean`` and ``away_goals_mean`` and
+default to ``1.0`` for both sides.
 
 ## License
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,7 +8,6 @@ from .simulator import (
     simulate_relegation_chances,
     simulate_final_table,
     summary_table,
-    DEFAULT_TIE_PERCENT,
     DEFAULT_HOME_FIELD_ADVANTAGE,
     DEFAULT_JOBS,
 )
@@ -22,7 +21,6 @@ __all__ = [
     "simulate_relegation_chances",
     "simulate_final_table",
     "summary_table",
-    "DEFAULT_TIE_PERCENT",
     "DEFAULT_HOME_FIELD_ADVANTAGE",
     "DEFAULT_JOBS",
     "estimate_parameters",


### PR DESCRIPTION
## Summary
- Switch simulation core to always use Poisson goal generation with 1.0 default means and drop win/draw/loss model
- Default CLI and public APIs to 1.0 goal means and remove obsolete tie probability parameter
- Refresh documentation and tests for the Poisson-centric approach

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689901b5c2ac8325b7a9b79b7d484881